### PR TITLE
Remove unused @babel/runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
    },
    "dependencies": {
       "@apollo/client": "4.2.0",
-      "@babel/runtime": "8.0.0",
       "github-markdown-css": "5.9.0",
       "graphql": "17.0.0",
       "marked-react": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@apollo/client':
         specifier: 4.2.0
         version: 4.2.0(graphql@17.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rxjs@7.8.2)
-      '@babel/runtime':
-        specifier: 8.0.0
-        version: 8.0.0
       github-markdown-css:
         specifier: 5.9.0
         version: 5.9.0
@@ -131,9 +128,6 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/runtime@8.0.0':
-    resolution: {integrity: sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -2138,8 +2132,6 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
-
-  '@babel/runtime@8.0.0': {}
 
   '@babel/template@7.29.7':
     dependencies:


### PR DESCRIPTION
Closes / supersedes part of #186.

`@babel/runtime` was listed as a direct dependency but is never imported anywhere in the source code, and no package in the dependency tree depends on it directly. This PR removes it entirely.

The remaining `@babel/*` packages in the lockfile are transitive dependencies pulled in by `next` / `eslint-config-next`, so they are still present and correct.